### PR TITLE
Allow getting a single translation value

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -191,6 +191,16 @@ trait HasTranslations
     }
 
     /**
+     * @param string $locale
+     * @param string $name
+     * @return mixed
+     */
+    public function getTranslationValue(string $locale, string $name)
+    {
+        return $this->translations()->where($this->getLocaleKeyName(), $locale)->value($name);
+    }
+
+    /**
      * The locale key name.
      *
      * @return string


### PR DESCRIPTION
Sometimes you may want to only get a single translated value, this PR adds this functionality.